### PR TITLE
Remove Middleware Contract

### DIFF
--- a/src/ForceHttpsUrlScheme.php
+++ b/src/ForceHttpsUrlScheme.php
@@ -3,14 +3,13 @@ namespace Shin1x1\ForceHttpsUrlScheme;
 
 use Closure;
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Contracts\Routing\Middleware;
 use Illuminate\Http\Request;
 
 /**
  * Class ForceHttpsUrlScheme
  * @package Shin1x1\ForceHttpsUrlScheme
  */
-class ForceHttpsUrlScheme implements Middleware
+class ForceHttpsUrlScheme
 {
     /**
      * @var Application


### PR DESCRIPTION
The Illuminate\Contracts\Routing\Middleware contract has been deprecated since version 5.1. No contract is required on your middleware.

https://laravel.com/docs/5.1/upgrade
